### PR TITLE
feat: add omit_headers middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ services:
           - ip-500/d  # Limit to 500 requests per day per IP
         
         openapi: /path/to/openapi.yaml  # OpenAPI file for request/response validation
+
+        omit_headers: [Authorization, X-API-Key, X-Secret-Token]
 ```
 
 ### Breakdown:

--- a/cmd/config.yaml
+++ b/cmd/config.yaml
@@ -30,3 +30,5 @@ services:
           - ip-100/d
 
         openapi: openapi.yaml
+
+        omit_headers: [Authorization, X-API-Key, X-Secret-Token]

--- a/config-schema.json
+++ b/config-schema.json
@@ -96,6 +96,13 @@
 										"servers"
 									]
 								},
+								"omit_headers": {
+									"type": "array",
+									"description": "List of headers to omit for secrets protection.",
+									"items": {
+										"type": "string"
+									}
+								},
 								"minify": {
 									"type": "array",
 									"items": {

--- a/config/config.go
+++ b/config/config.go
@@ -52,6 +52,7 @@ type Path struct {
 	Directory   *string            `yaml:"directory"`   // path to dir you want to serve
 	Backend     *Backend           `yaml:"backend"`     // List of servers to load balance between
 	Headers     *map[string]string `yaml:"headers"`
+	OmitHeaders []string           `yaml:"omit_headers"` // Omit specified headers
 	Minify      []string           `yaml:"minify"`
 	Gzip        *bool              `yaml:"gzip"`
 	Timeout     time.Duration      `yaml:"timeout"`

--- a/handler.go
+++ b/handler.go
@@ -73,6 +73,10 @@ func BuildHandler(service config.Service, path config.Path) (http.Handler, error
 		handlerWithMiddlewares.Add(middlewares.GzipMiddleware)
 	}
 
+	if len(path.OmitHeaders) > 0 {
+		handlerWithMiddlewares.Add(middlewares.NewOmitHeadersMiddleware(path.OmitHeaders))
+	}
+
 	minifyConfig := middlewares.MinifyConfig{
 		ALL:  slices.Contains(path.Minify, "all"),
 		JS:   slices.Contains(path.Minify, "js"),

--- a/middlewares/omit_headers.go
+++ b/middlewares/omit_headers.go
@@ -1,0 +1,24 @@
+package middlewares
+
+import (
+	"net/http"
+)
+
+// OmitHeaders middleware removes specified headers from the response to enhance security.
+func NewOmitHeadersMiddleware(headers []string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+			rc := NewResponseCapture(w)
+			next.ServeHTTP(rc, r)
+
+			// Omit headers from response
+			for _, header := range headers {
+				rc.Header().Del(header)
+			}
+
+			w.WriteHeader(rc.status)
+			w.Write(rc.buffer.Bytes())
+		})
+	}
+}

--- a/middlewares/omit_headers_test.go
+++ b/middlewares/omit_headers_test.go
@@ -1,0 +1,38 @@
+package middlewares_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hvuhsg/gatego/middlewares"
+)
+
+// TestOmitHeadersMiddleware_OmitResponseHeaders tests that headers are omitted from the response
+func TestOmitHeadersMiddleware_OmitResponseHeaders(t *testing.T) {
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Authorization", "Bearer some-secret-token")
+		w.Header().Set("X-API-Key", "secret-api-key")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	})
+
+	headers := []string{"Authorization", "X-API-Key"}
+	handler := middlewares.NewOmitHeadersMiddleware(headers)(nextHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Header().Get("Authorization") != "" {
+		t.Errorf("expected 'Authorization' header to be omitted, got %s", rr.Header().Get("Authorization"))
+	}
+	if rr.Header().Get("X-API-Key") != "" {
+		t.Errorf("expected 'X-API-Key' header to be omitted, got %s", rr.Header().Get("X-API-Key"))
+	}
+
+	if rr.Body.String() != "OK" {
+		t.Errorf("expected 'OK', got %s", rr.Body.String())
+	}
+}


### PR DESCRIPTION
Add middleware to omit secret headers. 
It's also placed under `secrets` object with the intention of adding more cool secret protections in the future. 
Hope it's not premature optimization :)